### PR TITLE
Initial source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ A Moodle webservice protocol implementation that allows requests with bodies. It
 
 1. Place this repository in `/webservice/loadedrest`.
 2. Execute the Moodle upgrades via the CLI or web UI.
+
+## Configuration
+
+1. Ensure _Enable web services_ is enabled under _Site administration_ > _Advanced features_.
+2. Navigate to _Site administration_ > _Plugins_ > _Web services_ > _Manage protocols_ and enable _Loaded REST protocol_.
+3. Assign the _Use Loaded REST protocol_ capability to the desired roles under _Site administration_ > _Users_ > _Permissions_ > _Define roles_.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,28 @@ A Moodle webservice protocol implementation that allows requests with bodies. It
 1. Ensure _Enable web services_ is enabled under _Site administration_ > _Advanced features_.
 2. Navigate to _Site administration_ > _Plugins_ > _Web services_ > _Manage protocols_ and enable _Loaded REST protocol_.
 3. Assign the _Use Loaded REST protocol_ capability to the desired roles under _Site administration_ > _Users_ > _Permissions_ > _Define roles_.
+
+## Sample client usage
+
+```php
+use webservice_loadedrest\client;
+
+$serverurl = '/webservice/loadedrest/server.php';
+$token = '000000000000000000000000000000000000';
+$httpmethod = 'PUT';
+$wsfunction = 'component_function';
+$params = [
+    'myargs' => [
+        [
+            'param' => 'look, nesting!',
+        ],
+    ],
+];
+
+$client = new client($serverurl, $token);
+try {
+    var_dump($client->call($httpmethod, $wsfunction, $params));
+} catch (Exception $e) {
+    var_dump($e);
+}
+```

--- a/classes/client.php
+++ b/classes/client.php
@@ -1,0 +1,106 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+namespace webservice_loadedrest;
+
+use moodle_exception;
+use moodle_url;
+use webservice_loadedrest\format\format_factory;
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Test webservice client.
+ */
+class client {
+    /**
+     * Path to server.php, relative to wwwroot.
+     *
+     * @var string
+     */
+    protected $serverurl;
+
+    /**
+     * Authentication token.
+     *
+     * @var string
+     */
+    protected $token;
+
+    /**
+     * I/O format.
+     *
+     * @var string|null
+     */
+    protected $formatname;
+
+    /**
+     * Initialiser.
+     *
+     * @param string $baseurl
+     * @param string $token
+     * @param string|null $format
+     */
+    public function __construct($baseurl, $token, $format=null) {
+        $this->serverurl = $baseurl;
+        $this->token = $token;
+        $this->formatname = $format ?? format_factory::FORMAT_DEFAULT;
+    }
+
+    /**
+     * Call an external function.
+     *
+     * @param $httpmethod
+     * @param $wsfunction
+     * @param $bodyparams
+     *
+     * @return mixed
+     *
+     * @throws moodle_exception
+     */
+    public function call($httpmethod, $wsfunction, $bodyparams) {
+        $format = format_factory::create($this->formatname);
+
+        $getparams = [
+            'wstoken'    => $this->token,
+            'wsfunction' => $wsfunction,
+        ];
+        $url = new moodle_url($this->serverurl, $getparams);
+        $headers = [
+            'Content-Type' => $this->formatname,
+        ];
+        $body = $format->serialise($bodyparams);
+
+        $curl = curl_init($url->out(false));
+        curl_setopt_array($curl, [
+            CURLOPT_CUSTOMREQUEST  => $httpmethod,
+            CURLOPT_HTTPHEADER     => $headers,
+            CURLOPT_POSTFIELDS     => $body,
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+        $result = curl_exec($curl);
+
+        return $format->deserialise($result);
+    }
+}

--- a/classes/format/abstract_format.php
+++ b/classes/format/abstract_format.php
@@ -1,0 +1,72 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+namespace webservice_loadedrest\format;
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Base format implementation.
+ *
+ * Contains just enough logic
+ */
+abstract class abstract_format implements format {
+    /**
+     * @inheritdoc
+     */
+    public function send_headers() {
+        $this->send_access_control_headers();
+        $this->send_cache_control_headers();
+        $this->send_accept_headers();
+    }
+
+    /**
+     * Send cache control headers.
+     *
+     * @return void
+     */
+    protected function send_cache_control_headers() {
+        header('Cache-Control: private, must-revalidate, pre-check=0, post-check=0, max-age=0');
+        header('Expires: '. gmdate('D, d M Y H:i:s', 0) .' GMT');
+        header('Pragma: no-cache');
+    }
+
+    /**
+     * Send access control headers.
+     *
+     * @return void
+     */
+    protected function send_access_control_headers() {
+        header('Access-Control-Allow-Origin: *');
+    }
+
+    /**
+     * Send accept headers.
+     *
+     * @return void
+     */
+    protected function send_accept_headers() {
+        header('Accept-Ranges: none');
+    }
+}

--- a/classes/format/format.php
+++ b/classes/format/format.php
@@ -1,0 +1,91 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+namespace webservice_loadedrest\format;
+
+use Exception;
+use external_description;
+use invalid_parameter_exception;
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Web service format.
+ */
+interface format {
+    /**
+     * Get the WS format name.
+     *
+     * @return string
+     */
+    public function get_name();
+
+    /**
+     * Serialise a request body from parameters.
+     *
+     * @param mixed[] $params
+     *
+     * @return string
+     */
+    public function serialise($params);
+
+    /**
+     * Parse request body.
+     *
+     * @param string $body
+     *
+     * @return mixed
+     *
+     * @throws invalid_parameter_exception
+     */
+    public function deserialise($body);
+
+    /**
+     * Send HTTP response headers.
+     *
+     * Headers, with the exception of the status line, are expected to be
+     * consistent across both successful responses and error responses. If we
+     * were asked to return JSON, we will not return errors in HTML.
+     *
+     * @return void
+     */
+    public function send_headers();
+
+    /**
+     * Send an error.
+     *
+     * @return void
+     */
+    public function send_error(Exception $exception);
+
+    /**
+     * Send a response.
+     *
+     * @param mixed $result
+     * @param external_description $description
+     *
+     * @return void
+     */
+    public function send_response($result, external_description $description);
+}

--- a/classes/format/format_factory.php
+++ b/classes/format/format_factory.php
@@ -1,0 +1,85 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+namespace webservice_loadedrest\format;
+
+use coding_exception;
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Format factory.
+ */
+class format_factory {
+    /**
+     * Format class name format.
+     *
+     * @var string
+     */
+    const CLASS_NAME_FORMAT = '\\webservice_loadedrest\\format\\%s_format';
+
+    /**
+     * Default body format name.
+     *
+     * @var string
+     */
+    const FORMAT_DEFAULT = 'json';
+
+    /**
+     * Create an instance of the named format.
+     *
+     * @param string $name
+     * @return format
+     * @throws coding_exception when supplied an invalid format name
+     */
+    public static function create($name) {
+        $classname = sprintf(static::CLASS_NAME_FORMAT, $name);
+
+        if (!class_exists($classname)) {
+            throw new coding_exception(sprintf('invalid format "%s"'), $name);
+        }
+
+        return new $classname();
+    }
+
+    /** @noinspection PhpDocMissingThrowsInspection */
+    /**
+     * Create an instance of the named format, falling back to the default.
+     *
+     * @param string $name
+     * @return format
+     */
+    public static function create_or_default($name) {
+        try {
+            $format = format_factory::create($name);
+        } catch (coding_exception $e) {
+            /** @noinspection PhpUnhandledExceptionInspection */
+            $format = format_factory::create(static::FORMAT_DEFAULT);
+            debugging(sprintf(
+                    'loaded rest: invalid format "%s"; falling back to default "%s"',
+                    $name), static::FORMAT_DEFAULT);
+        }
+        return $format;
+    }
+}

--- a/classes/format/json_format.php
+++ b/classes/format/json_format.php
@@ -1,0 +1,101 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+namespace webservice_loadedrest\format;
+
+use Exception;
+use external_description;
+use invalid_parameter_exception;
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * JSON format.
+ */
+class json_format extends abstract_format implements format {
+    /**
+     * @inheritdoc
+     */
+    public function get_name() {
+        return 'json';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function serialise($params) {
+        return json_encode($params);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function deserialise($body) {
+        json_decode('[]');
+        $result = json_decode($body, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new invalid_parameter_exception(
+                    'request body could not be parsed as valid json');
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function send_headers() {
+        parent::send_headers();
+        header('Content-Type: application/json');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function send_error(Exception $exception) {
+        $error = (object) [
+            'success' => false,
+            'exception' => (object) [
+                'class' => get_class($exception),
+                'code'    => $exception->getCode(),
+                'message' => $exception->getMessage(),
+            ],
+        ];
+
+        if (debugging() && property_exists($exception, 'debuginfo')) {
+            /** @noinspection PhpUndefinedFieldInspection */
+            $error->exception->debug = $exception->debuginfo;
+        }
+
+        echo json_encode($error);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function send_response($result, external_description $description) {
+        echo json_encode($result);
+    }
+}

--- a/classes/format/xml_format.php
+++ b/classes/format/xml_format.php
@@ -1,0 +1,185 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+namespace webservice_loadedrest\format;
+
+use coding_exception;
+use Exception;
+use external_description;
+use external_multiple_structure;
+use external_single_structure;
+use external_value;
+use invalid_parameter_exception;
+use XMLWriter;
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * XML format.
+ */
+class xml_format extends abstract_format implements format {
+    /**
+     * XML version.
+     *
+     * @var string
+     */
+    const VERSION = '1.0';
+
+    /**
+     * XML document encoding.
+     *
+     * @var string
+     */
+    const ENCODING = 'utf-8';
+
+    /**
+     * @inheritdoc
+     */
+    public function get_name() {
+        return 'xml';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function serialise($params) {
+        throw new coding_exception('unimplemented');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function deserialise($body) {
+        $oldvalue = libxml_use_internal_errors(true);
+        $data = simplexml_load_string($body);
+        $errors = libxml_get_errors();
+        libxml_use_internal_errors($oldvalue);
+
+        if ($data === false) {
+            throw new invalid_parameter_exception(
+                    'mangled and hideous though it was, request body could not'
+                    . ' be parsed as valid xml');
+        }
+
+        return json_decode(json_encode($data), true);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function send_headers() {
+        parent::send_headers();
+        header('Content-Type: application/xml; charset=utf-8');
+        header('Content-Disposition: inline; filename="response.xml"');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function send_error(Exception $exception) {
+        $doc = new XMLWriter();
+        $doc->openMemory();
+        $doc->startDocument(static::VERSION, static::ENCODING);
+            $doc->startElement('response');
+                $doc->startElement('success');
+                    $doc->text('false');
+                $doc->endElement();
+                $doc->startElement('exception');
+                    $doc->startAttribute('class');
+                        $doc->text(get_class($exception));
+                    $doc->endAttribute();
+                    $doc->startAttribute('code');
+                        $doc->text($exception->getCode());
+                    $doc->endAttribute();
+                $doc->startElement('message');
+                    $doc->text($exception->getMessage());
+                $doc->endElement();
+
+        if (debugging() && property_exists($exception, 'debuginfo')) {
+            $doc->startElement('debug');
+            /** @noinspection PhpUndefinedFieldInspection */
+            $doc->text($exception->debuginfo);
+            $doc->endElement();
+        }
+
+            $doc->endElement();
+        $doc->endDocument();
+        echo $doc->outputMemory();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function send_response($result, external_description $description) {
+        $doc = new XMLWriter();
+        $doc->openMemory();
+        $doc->startDocument(static::VERSION, static::ENCODING);
+            $doc->startElement('response');
+                $this->to_xml($doc, $result, $description);
+            $doc->endElement();
+        $doc->endDocument();
+        echo $doc->outputMemory();
+    }
+
+    /**
+     * Dump the result to XML.
+     *
+     * @param XMLWriter $doc
+     * @param $result
+     * @param external_description $description
+     * @param string|null $key
+     */
+    protected function to_xml(XMLWriter $doc, $result, external_description $description, $key=null) {
+        $singlekey = $key ?? 'value';
+
+        if ($description instanceof external_value) {
+            switch ($description->type) {
+                case PARAM_BOOL:
+                    $doc->startElement($singlekey);
+                    $doc->text($result ? 'true' : 'false');
+                    $doc->endElement();
+                    break;
+                default:
+                    $doc->startElement($singlekey);
+                    $doc->text($result);
+                    $doc->endElement();
+            }
+        } elseif ($description instanceof external_single_structure) {
+            $doc->startElement($singlekey);
+            foreach ($description->keys as $singlekey => $keydescription) {
+                $this->to_xml($doc, $result[$singlekey], $keydescription, $singlekey);
+            }
+            $doc->endElement();
+        } elseif ($description instanceof external_multiple_structure) {
+            $doc->startElement($singlekey);
+            foreach ($result as $resultitem) {
+                $this->to_xml($doc, $resultitem, $description->content, $singlekey);
+            }
+            $doc->endElement();
+        } else {
+            throw new coding_exception(sprintf(
+                    'unknown external_description type %s', get_class($description)));
+        }
+    }
+}

--- a/classes/server.php
+++ b/classes/server.php
@@ -1,0 +1,220 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+namespace webservice_loadedrest;
+
+use external_api;
+use invalid_response_exception;
+use webservice_base_server;
+use webservice_loadedrest\format\format;
+use webservice_loadedrest\format\format_factory;
+
+defined('MOODLE_INTERNAL') || die;
+require_once "{$CFG->libdir}/externallib.php";
+require_once "{$CFG->dirroot}/webservice/lib.php";
+
+/**
+ * Webservice server.
+ */
+class server extends webservice_base_server {
+    /**
+     * Moodle component namre.
+     *
+     * @var string
+     */
+    const COMPONENT_NAME = 'webservice_loadedrest';
+
+    /**
+     * Web service protocol name.
+     *
+     * @var string
+     */
+    const PROTOCOL_NAME = 'loadedrest';
+
+    /**
+     * HTTP status line: 403 forbidden.
+     *
+     * @var string
+     */
+    const HTTP_STATUS_FORBIDDEN = '%s 403 Forbidden';
+
+    /**
+     * Parameter: body format.
+     *
+     * @var string
+     */
+    const PARAM_BODYFORMAT = 'wsformat';
+
+    /**
+     * Parameter: function name.
+     *
+     * @var string
+     */
+    const PARAM_FUNCTION = 'wsfunction';
+
+    /**
+     * Parameter: authentication token.
+     *
+     * @var string
+     */
+    const PARAM_TOKEN = 'wstoken';
+
+    /**
+     * REST request and response body format.
+     *
+     * One of the FORMAT_* values.
+     *
+     * @var string
+     */
+    protected $formatname;
+
+    /**
+     * REST request and response body format.
+     *
+     * @var \webservice_loadedrest\format\format
+     */
+    protected $format;
+
+    /**
+     * Input stream.
+     *
+     * Which file should be opened to obtain the content of the request body?
+     *
+     * @var string
+     */
+    protected $inputstream;
+
+    /**
+     * Is the protocol enabled?
+     *
+     * @return bool
+     */
+    public static function is_enabled() {
+        return webservice_protocol_is_enabled(static::PROTOCOL_NAME);
+    }
+
+    /**
+     * 403 and exit unless the protocol is enabled.
+     *
+     * @return void
+     */
+    public static function require_enabled() {
+        if (!static::is_enabled()) {
+            // Guard against misconfigured FastCGI parameters
+            $protocol = array_key_exists('SERVER_PROTOCOL', $_SERVER)
+                    ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0';
+            header(sprintf(static::HTTP_STATUS_FORBIDDEN, $protocol));
+            exit;
+        }
+    }
+
+    /**
+     * Initialiser.
+     *
+     * @param format|null $format
+     * @param string|null $inputstream Defaults to "php://input" if not specified.
+     */
+    public function __construct(format $format=null, $inputstream=null) {
+        parent::__construct(WEBSERVICE_AUTHMETHOD_PERMANENT_TOKEN);
+        $this->wsname = static::PROTOCOL_NAME;
+
+        if ($format) {
+            $this->formatname = $format->get_name();
+            $this->format = $format;
+        } else {
+            $this->formatname = format_factory::FORMAT_DEFAULT;
+        }
+
+        $this->inputstream = $inputstream ?? 'php://input';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function parse_request() {
+        parent::set_web_service_call_settings();
+        $params = array_merge($_GET, $_POST);
+
+        if ($this->format === null) {
+            if (array_key_exists(static::PARAM_BODYFORMAT, $params)) {
+                $this->formatname = $params[static::PARAM_BODYFORMAT];
+            } elseif (array_key_exists('HTTP_CONTENT_TYPE', $_SERVER)) {
+                $contenttypeparts = [];
+                preg_match('%^application/(.+)%',
+                        $_SERVER['HTTP_CONTENT_TYPE'],
+                        $contenttypeparts);
+                if (count($contenttypeparts) === 2) {
+                    $this->formatname = $contenttypeparts[1];
+                }
+            }
+            $this->format = format_factory::create_or_default(
+                    $this->formatname);
+        }
+
+        if (array_key_exists(static::PARAM_TOKEN, $params)) {
+            $this->token = $params[static::PARAM_TOKEN];
+        }
+        if (array_key_exists(static::PARAM_FUNCTION, $params)) {
+            $this->functionname = $params[static::PARAM_FUNCTION];
+        }
+
+        $body = file_get_contents($this->inputstream);
+        $this->parameters = $this->format->deserialise($body);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function execute() {
+        parent::execute();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function send_response() {
+        $cleanvalue = null;
+        try {
+            if ($this->function->returns_desc !== null) {
+                $cleanvalue = external_api::clean_returnvalue(
+                        $this->function->returns_desc, $this->returns);
+            }
+        } catch (invalid_response_exception $e) {
+            $this->format->send_headers();
+            $this->format->send_error($e);
+            return;
+        }
+
+        $this->format->send_headers();
+        $this->format->send_response($cleanvalue, $this->function->returns_desc);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function send_error($exception=null) {
+        $this->format->send_headers();
+        $this->format->send_error($exception);
+    }
+}

--- a/db/access.php
+++ b/db/access.php
@@ -23,8 +23,11 @@
  */
 
 defined('MOODLE_INTERNAL') || die;
-/** @var string[] $string */
 
-$string['pluginname'] = 'Loaded REST protocol';
-
-$string['loadedrest:use'] = 'Use Loaded REST protocol';
+$capabilities = [
+    'webservice/loadedrest:use' => [
+        'contextlevel' => CONTEXT_SYSTEM,
+        'captype' => 'read',
+        'archetypes' => [],
+    ],
+];

--- a/lang/en/webservice_loadedrest.php
+++ b/lang/en/webservice_loadedrest.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+defined('MOODLE_INTERNAL') || die;
+/** @var string[] $string */
+
+$string['pluginname'] = 'Loaded REST protocol';

--- a/server.php
+++ b/server.php
@@ -1,0 +1,34 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+use webservice_loadedrest\server;
+
+define('NO_DEBUG_DISPLAY', true);
+define('WS_SERVER', true);
+require_once dirname(dirname(__DIR__)) . '/config.php';
+
+server::require_enabled();
+
+$server = new server();
+$server->run();

--- a/tests/json_format_test.php
+++ b/tests/json_format_test.php
@@ -1,0 +1,116 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+use webservice_loadedrest\format\json_format;
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Loaded REST server test suite.
+ *
+ * @group webservice_loadedrest
+ */
+class webservice_loadedrest_json_format_testcase extends advanced_testcase {
+    public function data_deserialise() {
+        return [
+            [
+                'body'   => '{"some":"text"}',
+                'expect' => [
+                    'some' => 'text',
+                ],
+            ],
+            [
+                'body'   => '{"some":1}',
+                'expect' => [
+                    'some' => 1,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider data_deserialise
+     */
+    public function test_deserialise($body, $expect) {
+        $format = new json_format();
+        $this->assertEquals($expect, $format->deserialise($body));
+    }
+
+    public function test_deserialise_resets_json_last_error() {
+        json_decode('{');
+        $this->assertNotEquals(JSON_ERROR_NONE, json_last_error());
+
+        $format = new json_format();
+        $this->assertEquals([], $format->deserialise('{}'));
+        $this->assertEquals(JSON_ERROR_NONE, json_last_error());
+    }
+
+    /**
+     * @expectedException invalid_parameter_exception
+     * @expectedExceptionMessage request body could not be parsed as valid json
+     */
+    public function test_deserialise_throws() {
+        $format = new json_format();
+        $format->deserialise('{');
+    }
+
+    public function test_send_error() {
+        $format = new json_format();
+        $exception = new Exception('message', 1);
+
+        ob_start();
+        $format->send_error($exception);
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $expected = sprintf(
+                '{"success":false,"exception":{"class":"Exception","code":%s,"message":"message"}}',
+                1);
+        $this->assertEquals($expected, $output);
+    }
+
+    public function test_send_error_debuginfo() {
+        global $CFG;
+
+        $this->resetAfterTest();
+        $format = new json_format();
+        $exception = new invalid_parameter_exception('additional info');
+
+        $CFG->debug = DEBUG_NONE;
+        ob_start();
+        $format->send_error($exception);
+        $output = ob_get_contents();
+        ob_end_clean();
+        $output = json_decode($output);
+        $this->assertObjectNotHasAttribute('debug', $output->exception);
+
+        $CFG->debug = DEBUG_DEVELOPER;
+        ob_start();
+        $format->send_error($exception);
+        $output = ob_get_contents();
+        ob_end_clean();
+        $output = json_decode($output);
+        $this->assertEquals('additional info', $output->exception->debug);
+    }
+}

--- a/tests/server_test.php
+++ b/tests/server_test.php
@@ -1,0 +1,146 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamFile;
+use webservice_loadedrest\format\format;
+use webservice_loadedrest\server;
+
+defined('MOODLE_INTERNAL') || die;
+
+class webservice_loadedrest_server_mock extends server {
+    protected function authenticate_by_token($tokentype) {
+        global $USER;
+
+        $this->restricted_context = context_system::instance();
+
+        return $USER;
+    }
+
+    protected function parse_request() {
+        parent::parse_request();
+        $this->functionname = 'webservice_loadedrest_external_mock_function';
+    }
+
+    protected function load_function_info() {
+        $function = (object) [
+            'id' => 1000000,
+            'name' => $this->functionname,
+            'classname' => 'webservice_loadedrest_external_mock',
+            'methodname' => 'mock_external_function',
+            'classpath' => __FILE__,
+            'component' => 'webservice_loadedrest',
+            'capabilities' => '',
+            'services' => null,
+        ];
+        $this->function = external_api::external_function_info($function);
+    }
+}
+
+class webservice_loadedrest_external_mock extends external_api {
+    public static function mock_external_function_parameters() {
+        return new external_function_parameters([
+            'vfsStream' => new external_value(
+                    PARAM_TEXT, '', VALUE_REQUIRED),
+        ]);
+    }
+
+    public static function mock_external_function_returns() {
+        return new external_value(
+                PARAM_BOOL, '', VALUE_REQUIRED);
+    }
+
+    public static function mock_external_function($params) {}
+}
+
+/**
+ * Loaded REST server test suite.
+ *
+ * @group webservice_loadedrest
+ */
+class webservice_loadedrest_server_testcase extends advanced_testcase {
+    /**
+     * Safely create a mock.
+     *
+     * PHPUnit 6.0.0 removed the legacy getMock() method in favour of
+     * createMock(). Since Moodle 3.1 is stuck on PHPUnit 4.8.x we still need
+     * to support the older version.
+     *
+     * @param string $className
+     *
+     * @return PHPUnit_Framework_MockObject_MockObject|PHPUnit\Framework\MockObject\MockObject
+     */
+    public function createMock($originalClassName) {
+        $oldVersionClass = 'PHPUnit_Runner_Version';
+        $versionClass = class_exists($oldVersionClass)
+                ? $oldVersionClass : 'PHPUnit\Runner\Version';
+
+        $version = $versionClass::series();
+        if (version_compare($version, '5.4', '>=')) {
+            return parent::createMock($originalClassName);
+        } else {
+            // As compatible as possible with createMock() as introduced in
+            // 5.4.0, but without disallowMockingUnknownTypes() as it was
+            // introduced in phpunit/phpunit-mock-object v4.0
+            // (phpunit/phpunit v6.0):
+            // https://github.com/sebastianbergmann/phpunit/blob/5.4.0/src/Framework/TestCase.php#L1510-L1529
+            return $this->getMockBuilder($originalClassName)
+                ->disableOriginalConstructor()
+                ->disableOriginalClone()
+                ->disableArgumentCloning()
+                ->getMock();
+        }
+    }
+
+    public function test_invokes_format_correctly() {
+        if (!class_exists(vfsStream::class)) {
+            $this->markTestSkipped('vfsStream required; available in Moodle >= 3.3');
+        }
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $vfs = vfsStream::setup('webservice_loadedrest', null, [
+            'input' => 'vfsStream = life saver',
+        ]);
+        /** @var vfsStreamFile $inputfile */
+        $inputfile = $vfs->getChild('input');
+
+        $mockformat = $this->createMock(format::class);
+        $mockformat->expects($this->at(0))
+            ->method('get_name')
+            ->willReturn('mock');
+        $mockformat->expects($this->at(1))
+            ->method('deserialise')
+            ->with($inputfile->getContent())
+            ->willReturn(['vfsStream' => 'life saver']);
+        $mockformat->expects($this->at(2))
+            ->method('send_headers');
+        $mockformat->expects($this->at(3))
+            ->method('send_response');
+
+        $server = new webservice_loadedrest_server_mock($mockformat, $inputfile->url());
+        $server->run();
+    }
+}

--- a/tests/xml_format_test.php
+++ b/tests/xml_format_test.php
@@ -1,0 +1,145 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+use webservice_loadedrest\format\xml_format;
+
+defined('MOODLE_INTERNAL') || die;
+
+// Data providers seem to execute before the PHPUnit bootstrap, so Moodle's
+// classloader hasn't yet been enabled before we start instantiating external_*
+// objects.
+global $CFG;
+require_once $CFG->libdir . '/externallib.php';
+
+/**
+ * Loaded REST server test suite.
+ *
+ * @group webservice_loadedrest
+ */
+class webservice_loadedrest_xml_format_testcase extends advanced_testcase {
+    public function data_deserialise() {
+        return [
+            [
+                'body'   => '<request><some>text</some></request>',
+                'expect' => [
+                    'some' => 'text',
+                ],
+            ],
+            [
+                'body'   => '<request><some>1</some></request>',
+                'expect' => [
+                    'some' => 1,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider data_deserialise
+     */
+    public function test_deserialise($body, $expect) {
+        $format = new xml_format();
+        $this->assertEquals($expect, $format->deserialise($body));
+    }
+
+
+    /**
+     * @expectedException invalid_parameter_exception
+     * @expectedExceptionMessage mangled and hideous though it was, request body could not be parsed as valid xml
+     */
+    public function test_deserialise_throws() {
+        $format = new xml_format();
+        $format->deserialise('<trololol');
+    }
+
+    public function test_send_error() {
+        $format = new xml_format();
+        $exception = new Exception('message', 1);
+
+        ob_start();
+        $format->send_error($exception);
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertRegExp('%\<response\>.*\</response\>%', $output);
+        $this->assertRegExp('%\<success\>false\</success\>%', $output);
+        $this->assertRegExp('%\<exception%', $output);
+        $this->assertRegExp('%class="Exception"%', $output);
+        $this->assertRegExp('%code="1"%', $output);
+        $this->assertRegExp('%\<message\>message\</message\>%', $output);
+    }
+
+    public function data_send_response() {
+        return [
+            [
+                'result' => true,
+                'description' => new external_value(PARAM_BOOL),
+                'expect' => [
+                    '%<value>true</value>%',
+                ],
+            ],
+            [
+                'result' => [
+                    'key' => 3.14,
+                ],
+                'description' => new external_single_structure([
+                    'key' => new external_value(PARAM_FLOAT),
+                ]),
+                'expect' => [
+                    '%<key>3.14</key>%',
+                ],
+            ],
+            [
+                'result' => [
+                    [
+                        'key' => 3.14,
+                    ],
+                ],
+                'description' => new external_multiple_structure(new external_single_structure([
+                    'key' => new external_value(PARAM_FLOAT),
+                ])),
+                'expect' => [
+                    '%<key>3.14</key>%',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider data_send_response
+     */
+    public function test_send_response($result, external_description $description, $expect) {
+        $format = new xml_format();
+
+        ob_start();
+        $format->send_response($result, $description);
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertRegExp('%\<response\>.*\</response\>%', $output);
+        foreach ($expect as $regexp) {
+            $this->assertRegExp($regexp, $output);
+        }
+    }
+}

--- a/version.php
+++ b/version.php
@@ -1,0 +1,33 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loaded REST.
+ *
+ * @package webservice_loadedrest
+ * @author Luke Carrier <luke@carrier.im>
+ * @copyright 2018 Luke Carrier
+ */
+
+defined('MOODLE_INTERNAL') || die;
+/** @var stdClass $plugin */
+
+$plugin->component = 'webservice_loadedrest';
+
+$plugin->version = 2018050300;
+$plugin->release = '0.0.0';
+
+$plugin->requires = 2016052300;


### PR DESCRIPTION
Tired (will open issues after merging):
1. XML support for the WS client, since we don't have a `serialise()` implementation for it. Given that the client is currently unused, I suggest we avoid this for now. (#2)
2. The issue with XML request payloads containing tags with duplicate names inside of `external_multiple_structure` values still persists. The current mitigation is to just add a unique identifier to the end of the tag, e.g. an int we just increment each time. This is left to the developer. (#3)

Wired:
1. Parsing loaded requests with bodies, given the appropriate HTTP method (`PUT`!).
2. Basic WS client.

Inspired: cleaned up Git history.